### PR TITLE
Negative consumption correction

### DIFF
--- a/custom_components/comwatt/sensor.py
+++ b/custom_components/comwatt/sensor.py
@@ -45,7 +45,7 @@ class ComwattEnergySensor(SensorEntity):
 
     _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
     _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_state_class = SensorStateClass.TOTAL
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     def __init__(self, client, username, password, device):
         self._device = device


### PR DESCRIPTION
Corrects the problem that displays a negative consumption corresponding to the previous day's consumption when the sensor is reset to 0 at midnight.