### PR TITLE
:sparkles: Comwatt Versions Prior to Gen4

### DIFF
--- a/custom_components/comwatt/__init__.py
+++ b/custom_components/comwatt/__init__.py
@@ -19,7 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     # Init client
-    client = ComwattClient()
+    client = ComwattClient(entry.data["api"])
     await asyncio.to_thread(lambda: client.authenticate(entry.data["username"], entry.data["password"]))
     hass.data[DOMAIN][entry.entry_id] = client
 

--- a/custom_components/comwatt/config_flow.py
+++ b/custom_components/comwatt/config_flow.py
@@ -23,6 +23,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required("username"): str,
         vol.Required("password"): str,
+        vol.Optional("api", default="energy"): vol.In(["energy", "go"]),
     }
 )
 
@@ -40,7 +41,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     #     your_validate_func, data["username"], data["password"]
     # )
 
-    client = ComwattClient()
+    client = ComwattClient(data["api"])
     cwt_session = None
     try:
         await asyncio.to_thread(lambda: client.authenticate(data["username"], data["password"]))
@@ -61,7 +62,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     # InvalidAuth
 
     # Return info that you want to store in the config entry.
-    return {"title": data["username"]}
+    return {"title": data["username"], "api": data["api"]}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/comwatt/manifest.json
+++ b/custom_components/comwatt/manifest.json
@@ -12,7 +12,7 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "requirements": [
-    "comwatt-client==0.1.6"
+    "comwatt-client==0.1.7"
   ],
   "ssdp": [],
   "zeroconf": []

--- a/custom_components/comwatt/sensor.py
+++ b/custom_components/comwatt/sensor.py
@@ -30,11 +30,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 if 'partChilds' in device and len(device['partChilds']) > 0:
                     childs = device["partChilds"]
                     for child in childs:
-                        new_devices.append(ComwattPowerSensor(client, entry.data["username"], entry.data["password"], child))
-                        new_devices.append(ComwattEnergySensor(client, entry.data["username"], entry.data["password"], child))
+                        new_devices.append(ComwattPowerSensor(client, entry.data["username"], entry.data["password"], entry.data["api"], child))
+                        new_devices.append(ComwattEnergySensor(client, entry.data["username"], entry.data["password"], entry.data["api"], child))
                 else:
-                    new_devices.append(ComwattPowerSensor(client, entry.data["username"], entry.data["password"], device))
-                    new_devices.append(ComwattEnergySensor(client, entry.data["username"], entry.data["password"], device))
+                    new_devices.append(ComwattPowerSensor(client, entry.data["username"], entry.data["password"], entry.data["api"], device))
+                    new_devices.append(ComwattEnergySensor(client, entry.data["username"], entry.data["password"], entry.data["api"], device))
     # TODO: Remove existing devices?
     # TODO: Remove old existing devices?
     if new_devices:
@@ -47,11 +47,12 @@ class ComwattEnergySensor(SensorEntity):
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
-    def __init__(self, client, username, password, device):
+    def __init__(self, client, username, password, api, device):
         self._device = device
         self._client = client
         self._username = username
         self._password = password
+        self._api = api
         self._attr_unique_id = f"{self._device['id']}_total_energy"
         self._attr_name = f"{self._device['name']} Total Energy"
 
@@ -66,7 +67,7 @@ class ComwattEnergySensor(SensorEntity):
         try:
             time_series_data = self._client.get_device_ts_time_ago(self._device["id"], "VIRTUAL_QUANTITY", "HOUR", "NONE")
         except Exception:
-            self._client = ComwattClient()
+            self._client = ComwattClient(self._api)
             self._client.authenticate(self._username, self._password)
             time_series_data = self._client.get_device_ts_time_ago(self._device["id"], "VIRTUAL_QUANTITY", "HOUR", "NONE")
 
@@ -86,11 +87,12 @@ class ComwattPowerSensor(SensorEntity):
     _attr_device_class = SensorDeviceClass.POWER
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, client, username, password, device):
+    def __init__(self, client, username, password, api, device):
         self._device = device
         self._client = client
         self._username = username
         self._password = password
+        self._api = api
         self._attr_unique_id = f"{self._device['id']}_power"
         self._attr_name = f"{self._device['name']} Power"
 
@@ -104,7 +106,7 @@ class ComwattPowerSensor(SensorEntity):
         try:
             time_series_data = self._client.get_device_ts_time_ago(self._device["id"], "FLOW", "NONE", "NONE", "HOUR", 1)
         except Exception:
-            self._client = ComwattClient()
+            self._client = ComwattClient(self._api)
             self._client.authenticate(self._username, self._password)
             time_series_data = self._client.get_device_ts_time_ago(self._device["id"], "FLOW", "NONE", "NONE", "HOUR", 1)
 


### PR DESCRIPTION
This pull request introduces compatibility for Comwatt versions predating Gen4, which utilize the go.comwatt.com API instead of energy.comwatt.com. The change enables users to seamlessly switch between the two APIs based on their Comwatt version.

Fixing https://github.com/MateoGreil/homeassistant-comwatt/issues/7