### PR TITLE
⚡️ Request for EnergySensor only 1 per hour

### DIFF
--- a/custom_components/comwatt/sensor.py
+++ b/custom_components/comwatt/sensor.py
@@ -14,8 +14,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.event import (
+    async_track_time_interval,
+    async_track_utc_time_change,
+)
 
 import asyncio
+from datetime import timedelta
 from .const import DOMAIN
 from .client import comwatt_client
 
@@ -38,10 +43,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     # TODO: Remove existing devices?
     # TODO: Remove old existing devices?
+
     if new_devices:
-        async_add_entities(new_devices)
+        async_add_entities(new_devices, update_before_add=True)
 
 class ComwattSensor(SensorEntity):
+    @property
+    def should_poll(self) -> bool:
+        return False
+
     @property
     def device_info(self) -> DeviceInfo:
         """Return te devce info."""
@@ -58,6 +68,9 @@ class ComwattSensor(SensorEntity):
             name=self._device['name'],
             model=model
         )
+
+    async def _async_update(self, *args):
+        await self.hass.async_add_executor_job(self.update)
 
 class ComwattEnergySensor(ComwattSensor):
     """Representation of a Sensor."""
@@ -92,6 +105,13 @@ class ComwattEnergySensor(ComwattSensor):
             self._last_native_value_at = time_series_data["timestamps"][-1]
             self._attr_native_value += time_series_data["values"][-1]
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_track_utc_time_change(self.hass, self._async_update, minute=55, second=0)
+        )
+
 class ComwattPowerSensor(ComwattSensor):
     """Representation of a Sensor."""
 
@@ -118,3 +138,10 @@ class ComwattPowerSensor(ComwattSensor):
         # TODO: Update to the time of comwatt and not the current time
         if time_series_data["values"]:
             self._attr_native_value = time_series_data["values"][-1]
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_track_time_interval(self.hass, self._async_update, timedelta(minutes=2))
+        )

--- a/custom_components/comwatt/sensor.py
+++ b/custom_components/comwatt/sensor.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # TODO: Remove old existing devices?
 
     if new_devices:
-        async_add_entities(new_devices, update_before_add=True)
+        async_add_entities(new_devices)
 
 class ComwattSensor(SensorEntity):
     @property

--- a/custom_components/comwatt/switch.py
+++ b/custom_components/comwatt/switch.py
@@ -26,7 +26,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # TODO: Remove existing devices?
     # TODO: Remove old existing devices?
     if new_devices:
-        async_add_entities(new_devices)
+        async_add_entities(new_devices, update_before_add=True)
 
 
 class ComwattSwitch(SwitchEntity):

--- a/custom_components/comwatt/switch.py
+++ b/custom_components/comwatt/switch.py
@@ -26,7 +26,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # TODO: Remove existing devices?
     # TODO: Remove old existing devices?
     if new_devices:
-        async_add_entities(new_devices, update_before_add=True)
+        async_add_entities(new_devices)
 
 
 class ComwattSwitch(SwitchEntity):


### PR DESCRIPTION
Solving https://github.com/MateoGreil/homeassistant-comwatt/issues/3

Request for EnergySensor only 1 per hour.
As this sensor is :
```
    _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
    _attr_device_class = SensorDeviceClass.ENERGY
    _attr_state_class = SensorStateClass.TOTAL_INCREASING
```
It's not usefull to update it each 2 minutes.

This PR will reduce the number of request to comwatt servers, and probably avoid a bit the ban of IP (talked [here](https://github.com/MateoGreil/homeassistant-comwatt/issues/32) and [here](https://github.com/MateoGreil/homeassistant-comwatt/issues/33))