### PR TITLE
⚡️ Set polling interval to 2 minutes

### DIFF
--- a/custom_components/comwatt/sensor.py
+++ b/custom_components/comwatt/sensor.py
@@ -18,6 +18,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 import asyncio
 from .const import DOMAIN
 from .client import comwatt_client
+from datetime import timedelta
+
+SCAN_INTERVAL = timedelta(minutes=2)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     new_devices = []

--- a/custom_components/comwatt/switch.py
+++ b/custom_components/comwatt/switch.py
@@ -3,7 +3,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 import asyncio
 from .client import comwatt_client
+from datetime import timedelta
 
+SCAN_INTERVAL = timedelta(minutes=2)
 SWITCH_NATURE = ['POWER_SWITCH', 'RELAY']
 
 async def async_setup_entry(hass, entry, async_add_entities):


### PR DESCRIPTION
This PR addresses stability issues with the Comwatt integration by increasing the scan interval from the default 30 seconds to 2 minutes. 
By increasing the scan interval, we aim to improve the overall stability of the integration and prevent crashes caused by excessive polling of Comwatt servers. 