### PR TITLE
:recycle: Refactor Comwatt client usage to avoid multiple instances

### DIFF
--- a/custom_components/comwatt/__init__.py
+++ b/custom_components/comwatt/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .client import comwatt_client
+from comwatt_client import ComwattClient
 
 import asyncio
 
@@ -18,7 +18,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set default DOMAIN
     hass.data.setdefault(DOMAIN, {})
 
-    await asyncio.to_thread(lambda: comwatt_client.authenticate(entry.data["username"], entry.data["password"]))
+    client = ComwattClient()
+    await asyncio.to_thread(lambda: client.authenticate(entry.data["username"], entry.data["password"]))
+
+    hass.data[DOMAIN]["cookies"] = client.session.cookies.get_dict()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/comwatt/client.py
+++ b/custom_components/comwatt/client.py
@@ -1,3 +1,0 @@
-from comwatt_client import ComwattClient
-
-comwatt_client = ComwattClient()

--- a/custom_components/comwatt/config_flow.py
+++ b/custom_components/comwatt/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import HomeAssistantError
 from .const import DOMAIN
 
 import asyncio
-from .client import comwatt_client
+from comwatt_client import ComwattClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,10 +34,12 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     """
 
     cwt_session = None
-    try:
-        await asyncio.to_thread(lambda: comwatt_client.authenticate(data["username"], data["password"]))
+    client = ComwattClient()
 
-        for cookie in comwatt_client.session.cookies:
+    try:
+        await asyncio.to_thread(lambda: client.authenticate(data["username"], data["password"]))
+
+        for cookie in client.session.cookies:
             if cookie.name == "cwt_session":
                 cwt_session = cookie
                 break

--- a/custom_components/comwatt/switch.py
+++ b/custom_components/comwatt/switch.py
@@ -2,17 +2,22 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 
 import asyncio
-from .client import comwatt_client
+from .const import DOMAIN
+from comwatt_client import ComwattClient
 from datetime import timedelta
+
 
 SCAN_INTERVAL = timedelta(minutes=2)
 SWITCH_NATURE = ['POWER_SWITCH', 'RELAY']
 
 async def async_setup_entry(hass, entry, async_add_entities):
+    client = ComwattClient()
+    client.session.cookies.update(hass.data[DOMAIN]["cookies"])
+
     new_devices = []
-    sites = await asyncio.to_thread(lambda: comwatt_client.get_sites())
+    sites = await asyncio.to_thread(lambda: client.get_sites())
     for site in sites:
-        devices = await asyncio.to_thread(lambda: comwatt_client.get_devices(site['id']))
+        devices = await asyncio.to_thread(lambda: client.get_devices(site['id']))
         for device in devices:
             if 'id' in device:
                 if 'partChilds' in device and len(device['partChilds']) > 0:
@@ -70,58 +75,70 @@ class ComwattSwitch(SwitchEntity):
 
     def turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
+        client = ComwattClient()
+        client.session.cookies.update(self.hass.data[DOMAIN]["cookies"])
+
         try:
-            device = comwatt_client.get_device(self._ref)
+            device = client.get_device(self._ref)
             for feature in device['features']:
                 for capacity in feature['capacities']:
                     if capacity.get('capacity', {}).get('nature') in SWITCH_NATURE:
                         capacity_id = capacity['capacity']['id']
-            comwatt_client.switch_capacity(capacity_id, True)
+            client.switch_capacity(capacity_id, True)
 
         except Exception:
-            comwatt_client.authenticate(self._username, self._password)
-            device = comwatt_client.get_device(self._ref)
+            client.authenticate(self._username, self._password)
+            self.hass.data[DOMAIN]["cookies"] = client.session.cookies.get_dict()
+            device = client.get_device(self._ref)
             for feature in device['features']:
                 for capacity in feature['capacities']:
                     if capacity.get('capacity', {}).get('nature') in SWITCH_NATURE:
                         capacity_id = capacity['capacity']['id']
-            comwatt_client.switch_capacity(capacity_id, True)
+            client.switch_capacity(capacity_id, True)
 
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
+        client = ComwattClient()
+        client.session.cookies.update(self.hass.data[DOMAIN]["cookies"])
+
         try:
-            device = comwatt_client.get_device(self._ref)
+            device = client.get_device(self._ref)
             for feature in device['features']:
                 for capacity in feature['capacities']:
                     if capacity.get('capacity', {}).get('nature') in SWITCH_NATURE:
                         capacity_id = capacity['capacity']['id']
-            comwatt_client.switch_capacity(capacity_id, False)
+            client.switch_capacity(capacity_id, False)
 
         except Exception:
-            comwatt_client.authenticate(self._username, self._password)
-            device = comwatt_client.get_device(self._ref)
+            client.authenticate(self._username, self._password)
+            self.hass.data[DOMAIN]["cookies"] = client.session.cookies.get_dict()
+            device = client.get_device(self._ref)
             for feature in device['features']:
                 for capacity in feature['capacities']:
                     if capacity.get('capacity', {}).get('nature') in SWITCH_NATURE:
                         capacity_id = capacity['capacity']['id']
-            comwatt_client.switch_capacity(capacity_id, False)
+            client.switch_capacity(capacity_id, False)
 
         self.schedule_update_ha_state()
 
     def update(self) -> None:
         """Fetch new state data for the sensor."""
+        client = ComwattClient()
+        client.session.cookies.update(self.hass.data[DOMAIN]["cookies"])
+
         try:
-            device = comwatt_client.get_device(self._ref)
+            device = client.get_device(self._ref)
             for feature in device['features']:
                 for capacity in feature['capacities']:
                     if capacity.get('capacity', {}).get('nature') in SWITCH_NATURE:
                         self._is_on = capacity['capacity']['enable']
 
         except Exception:
-            comwatt_client.authenticate(self._username, self._password)
-            device = comwatt_client.get_device(self._ref)
+            client.authenticate(self._username, self._password)
+            self.hass.data[DOMAIN]["cookies"] = client.session.cookies.get_dict()
+            device = client.get_device(self._ref)
             for feature in device['features']:
                 for capacity in feature['capacities']:
                     if capacity.get('capacity', {}).get('nature') in SWITCH_NATURE:


### PR DESCRIPTION
This pull request addresses the issue of creating multiple instances of the Comwatt client and handles disconnection scenarios that require re-authentication. 

Could fix : https://github.com/MateoGreil/homeassistant-comwatt/issues/36

These changes ensure that a single instance of the Comwatt client is used throughout the integration and that disconnections are properly handled by re-authenticating and updating the session cookies. This should resolve issues related to disconnections and the need for manual resets. 