### PR TITLE
📄 Add The Unlicense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>


### PR DESCRIPTION
## Why

The `validate-hacs` job fails on main with:

> ❌ \`<Validation license> failed: The repository has no license\`

([failing run](https://github.com/MateoGreil/homeassistant-comwatt/actions/runs/28735241016/job/85208102660))

HACS requires the repository to have a license detected by GitHub.

## What

Add [The Unlicense](https://unlicense.org) (public domain dedication) as \`LICENSE\`, keeping the code as free as possible. The README already links to this file via its license badge, and already carries the "not affiliated with Comwatt" disclaimer.

Note: the HACS license check reads the license detected by GitHub on the default branch, so it will only turn green after this PR is merged.